### PR TITLE
Cancel transition when no matching choice

### DIFF
--- a/lib/finite_machine/transition.rb
+++ b/lib/finite_machine/transition.rb
@@ -79,7 +79,12 @@ module FiniteMachine
     def to_state(*args)
       if transition_choice?
         found_trans = machine.select_choice_transition(name, from_state, *args)
-        found_trans.map[from_state] || found_trans.map[ANY_STATE]
+
+        if found_trans.nil?
+          from_state
+        else
+          found_trans.map[from_state] || found_trans.map[ANY_STATE]
+        end
       else
         available_trans = machine.transitions[name]
         available_trans[from_state] || available_trans[ANY_STATE]

--- a/lib/finite_machine/transition.rb
+++ b/lib/finite_machine/transition.rb
@@ -153,7 +153,9 @@ module FiniteMachine
     # @api public
     def valid?(*args, &block)
       if transition_choice?
-        machine.check_choice_conditions(name, *args, &block)
+        machine.events_chain[name].state_transitions.select { |trans|
+          trans.check_conditions(*args, &block)
+        }.any?(&:current?)
       else
         check_conditions(*args, &block)
       end

--- a/spec/unit/choice_spec.rb
+++ b/spec/unit/choice_spec.rb
@@ -213,6 +213,34 @@ RSpec.describe FiniteMachine, '#choice' do
     expect(fsm.current).to eq(:fulfilled)
   end
 
+  it "does not transition when no matching choice for multiple event definitions" do
+    ticket = double(:ticket, :pending? => true, :finished? => false)
+    fsm = FiniteMachine.define do
+      initial :inactive
+
+      target ticket
+
+      events {
+        event :advance, from: [:inactive, :paused, :fulfilled] do
+          choice :active, if: proc { |_ticket| !_ticket.pending? }
+        end
+
+        event :advance, from: [:inactive, :active, :fulfilled] do
+          choice :paused, if: proc { |_ticket| _ticket.pending? }
+        end
+
+        event :advance, from: [:inactive, :active, :paused] do
+          choice :fulfilled, if: proc { |_ticket| _ticket.finished? }
+        end
+      }
+    end
+    expect(fsm.current).to eq(:inactive)
+    fsm.advance
+    expect(fsm.current).to eq(:paused)
+    fsm.advance
+    expect(fsm.current).to eq(:paused)
+  end
+
   it "sets callback properties correctly" do
     expected = {name: :init, from: :none, to: :red, a: nil, b: nil, c: nil }
 

--- a/spec/unit/choice_spec.rb
+++ b/spec/unit/choice_spec.rb
@@ -215,6 +215,7 @@ RSpec.describe FiniteMachine, '#choice' do
 
   it "does not transition when no matching choice for multiple event definitions" do
     ticket = double(:ticket, :pending? => true, :finished? => false)
+    called = []
     fsm = FiniteMachine.define do
       initial :inactive
 
@@ -233,12 +234,23 @@ RSpec.describe FiniteMachine, '#choice' do
           choice :fulfilled, if: proc { |_ticket| _ticket.finished? }
         end
       }
+
+      callbacks {
+        on_before(:advance) { called << 'on_before_advance' }
+        on_after(:advance)  { called << 'on_after_advance' }
+      }
     end
     expect(fsm.current).to eq(:inactive)
     fsm.advance
     expect(fsm.current).to eq(:paused)
     fsm.advance
     expect(fsm.current).to eq(:paused)
+    expect(called).to eq([
+      'on_before_advance',
+      'on_after_advance',
+      'on_before_advance',
+      'on_after_advance'
+    ])
   end
 
   it "sets callback properties correctly" do


### PR DESCRIPTION
The original logic was separately checking if 1) there were any valid defined transitions for the current state, and 2) if any of the transitions' conditions matched. By doing this separately, the check for whether an event transition was valid would provide incorrect results when the only transitions that had conditions that all passed were not defined transitions from the *current* state.

Once that check returned an incorrect result, the call later down the line to pull out the supposed "matching" transition would come up with air (or `nil`, in this case).

This bug fix originated from the discussion here: https://github.com/peter-murach/finite_machine/issues/35.