### PR TITLE
Halt all callbacks when transition cancelled

### DIFF
--- a/lib/finite_machine/events_chain.rb
+++ b/lib/finite_machine/events_chain.rb
@@ -233,19 +233,17 @@ module FiniteMachine
       transition.to_state(from_state)
     end
 
-    # Set cancelled status for all transitions matching event name
+    # Set status to cancelled for all transitions matching event name
     #
     # @param [Symbol] name
     #   the event name
-    # @param [Symbol] status
-    #   true to cancel, false otherwise
     #
     # @return [nil]
     #
     # @api public
-    def cancel_transitions(name, status)
+    def cancel_transitions(name)
       chain[name].each do |trans|
-        trans.cancelled = status
+        trans.cancelled = true
       end
     end
 

--- a/lib/finite_machine/observer.rb
+++ b/lib/finite_machine/observer.rb
@@ -170,8 +170,10 @@ module FiniteMachine
         result = callable.call(trans_event, *data)
       end
 
-      machine.events_chain.cancel_transitions(event.event_name,
-                                              (result == CANCELLED))
+      if result == CANCELLED
+        hooks.collection.clear
+        machine.events_chain.cancel_transitions(event.event_name)
+      end
     end
 
     # Callback names including all states and events

--- a/spec/unit/callbacks_spec.rb
+++ b/spec/unit/callbacks_spec.rb
@@ -708,6 +708,32 @@ RSpec.describe FiniteMachine, 'callbacks' do
     expect(fsm.current).to eql(:green)
   end
 
+  it "stops executing callbacks when cancelled" do
+    called = []
+
+    fsm = FiniteMachine.define do
+      initial :initial
+
+      events { event :bump, initial: :low }
+
+      callbacks {
+        on_before do |event|
+          called << "enter_#{event.name}_#{event.from}_#{event.to}"
+
+          FiniteMachine::CANCELLED
+        end
+
+        on_transition do |event|
+          called << "exit_#{event.name}_#{event.from}_#{event.to}"
+        end
+      }
+    end
+
+    fsm.bump
+
+    expect(called).to eq(['enter_bump_initial_low'])
+  end
+
   xit "groups callbacks"
 
   it "groups states from separate events with the same name" do

--- a/spec/unit/events_chain/cancel_transitions_spec.rb
+++ b/spec/unit/events_chain/cancel_transitions_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe FiniteMachine::EventsChain, '.cancel_transitions' do
     events_chain.add(:start, transition_b)
     events_chain.add(:finish, transition_c)
 
-    events_chain.cancel_transitions(:start, true)
+    events_chain.cancel_transitions(:start)
 
     expect(transition_a).to have_received(:cancelled=).with(true)
     expect(transition_b).to have_received(:cancelled=).with(true)


### PR DESCRIPTION
Hey, @peter-murach!

Here's a failing spec for an aspect of behavior I expect from the system when a transition is cancelled.

When `CANCELLED` is returned from a callback, I'd expect future callbacks in the chain to *not* be executed; however, right now they are. I'm working up a fix, but I'm certainly open to any help you can provide.